### PR TITLE
add support for conversion to .vtu (Paraview/VTK)

### DIFF
--- a/python/format_utils.py
+++ b/python/format_utils.py
@@ -1,7 +1,11 @@
 import meshio
 import h5py
+import vtk
 import numpy as np
-
+import pyvista as pv
+import numpy_indexed as npi
+from vtk_node_ordering import vtk_node_ordering
+from curve.fem_generator import tuple_gen
 
 def convert_cutet(file1, file2):
     # a handy conversion for the default output mesh (p4).
@@ -18,7 +22,50 @@ def convert_cutet(file1, file2):
     meshio.gmsh.write(file2,
                  meshio.Mesh(points=lagr, cells=[('tetra35', p4T[:, reorder])]))
 
+def codec_to_points(codec):
+
+    codec_op = np.eye(4)[codec].mean(axis=1)
+    points = codec_op@np.vstack([np.zeros(3),np.eye(3)])
+    return points
+
+def codec_to_n(co): return [k for i, j in enumerate(co) for k in [i]*j]
+
+def vtk_reordering(order, precision=5):
+    vtk_points = vtk_node_ordering(order)
+    codec = np.array(tuple_gen(order=order, var_n=3))
+
+    auto_cod_n = np.array([codec_to_n(c) for c in codec])
+    auto_points = codec_to_points(auto_cod_n)
+    reorder = npi.indices(np.round(auto_points, precision),
+                          np.round(vtk_points, precision), axis=0)
+    return reorder
+
+def convert_vtk(file1, file2):
+    with h5py.File(file1, 'r') as fp:
+        lagr, p4T = fp['lagr'][()], fp['cells'][()]
+
+    n_points_per_cell = p4T.shape[1]
+    n_cells = p4T.shape[0]
+
+    shape_order = {10:2, 20:3, 35:4, 56:5}
+    order = shape_order[n_points_per_cell]
+    reorder = vtk_reordering(order)
+
+    p4T = p4T[:,reorder]
+
+    cell_type = np.array([vtk.VTK_LAGRANGE_TETRAHEDRON]*n_cells)
+    cells = np.hstack( [np.ones((n_cells,1), dtype=np.int32)*n_points_per_cell, p4T])
+    grid = pv.UnstructuredGrid(cells, cell_type, lagr)
+    grid.save(file2)
+
 
 if __name__ == '__main__':
-    import sys
-    convert_cutet(sys.argv[1], sys.argv[2])
+    import sys, os
+    file_extension = os.path.splitext(sys.argv[2])[-1]
+    if file_extension==".msh":
+        convert_cutet(sys.argv[1],sys.argv[2])
+    elif file_extension==".vtu":
+        convert_vtk(sys.argv[1],sys.argv[2])
+    else:
+        print(f"file type {file_extension} not supported. Use gmsh (.msh) for P4 or .vtu for arbitrary order")
+

--- a/python/vtk_node_ordering.py
+++ b/python/vtk_node_ordering.py
@@ -1,0 +1,80 @@
+import numpy as np
+
+# from https://github.com/ju-kreber/paraview-scripts
+
+def np_array(ordering):
+    """Wrapper for np.array to simplify common modifications"""
+    return np.array(ordering, dtype=np.float64)
+
+def n_verts_between(n, frm, to):
+    """Places `n` vertices on the edge between `frm` and `to`"""
+    if n <= 0:
+        return np.ndarray((0, 3)) # empty
+    edge_verts = np.stack((
+        np.linspace(frm[0], to[0], num=n+1, endpoint=False, axis=0),   # n+1 since start is included, remove later
+        np.linspace(frm[1], to[1], num=n+1, endpoint=False, axis=0),
+        np.linspace(frm[2], to[2], num=n+1, endpoint=False, axis=0),
+        ), axis=1)
+    return edge_verts[1:] # remove start point
+
+def number_triangle(corner_verts, order, skip=False):
+    """Outputs the list of coordinates of a right-angled triangle of arbitrary order in the right ordering"""
+    if order < 0:
+        return np.ndarray((0, 3)) # empty
+    if order == 0: # single point, for recursion
+        assert np.isclose(corner_verts[0], corner_verts[1]).all() and np.isclose(corner_verts[0], corner_verts[2]).all() # all corners must be same point
+        return np.array([corner_verts[0]])
+
+    # first: corner vertices
+    coords = np_array(corner_verts) if not skip else np.ndarray((0, 3)) # empty if skip
+    if order == 1:
+        return coords
+    # second: edges
+    num_verts_on_edge = order - 1
+    edges = [(0,1), (1,2), (2,0)]
+    for frm, to in edges:
+        coords = np.concatenate([coords, n_verts_between(num_verts_on_edge, corner_verts[frm], corner_verts[to])], axis=0) if not skip else coords # do nothing if skip
+    if order == 2:
+        return coords
+    # third: face, use recursion
+    e_x = (corner_verts[1] - corner_verts[0]) / order
+    e_y = (corner_verts[2] - corner_verts[0]) / order
+    inc = np.array([e_x + e_y, -2*e_x + e_y, e_x -2*e_y]) # adjust corner vertices for recursion
+    return np.concatenate([coords, number_triangle(np.array(corner_verts) + inc, order - 3, skip=False)], axis=0) # recursive call, decrease order
+
+
+
+def number_tetrahedron(corner_verts, order):
+    """Outputs the list of coordinates of a right-angled tetrahedron of arbitrary order in the right ordering"""
+    if order < 0:
+        return np.ndarray((0, 3)) # empty
+    if order == 0: # single point
+        assert np.isclose(corner_verts[1], corner_verts[0]).all() and np.isclose(corner_verts[2], corner_verts[0]).all() and np.isclose(corner_verts[3], corner_verts[0]).all() # all corners must be same point
+        return np.array([corner_verts[0]])
+
+    # first: corner vertices
+    coords = np_array(corner_verts)
+    if order == 1:
+        return coords
+    # second: edges
+    num_verts_on_edge = order - 1
+    edges = [(0,1), (1,2), (2,0), (0,3), (1,3), (2,3)]
+    for frm, to in edges:
+        coords = np.concatenate([coords, n_verts_between(num_verts_on_edge, corner_verts[frm], corner_verts[to])], axis=0)
+    if order == 2:
+        return coords
+    # third: faces, use triangle numbering method
+    faces = [(0,1,3), (2,3,1), (0,3,2), (0,2,1)]  # x-z, top, y-z, x-y (CCW)  TODO: not as in documentation, beware of future changes!!
+    for v_x, v_y, v_z in faces:
+        coords = np.concatenate([coords, number_triangle([corner_verts[v_x], corner_verts[v_y], corner_verts[v_z]], order, skip=True)], axis=0) # use number_triangle to number face, but skip corners and edges
+    if order == 3:
+        return coords
+    # fourth: volume, use recursion
+    e_x = (corner_verts[1] - corner_verts[0]) / order
+    e_y = (corner_verts[2] - corner_verts[0]) / order
+    e_z = (corner_verts[3] - corner_verts[0]) / order
+    inc = np.array([e_x + e_y + e_z, -3*e_x + e_y + e_z, e_x -3*e_y + e_z, e_x + e_y -3*e_z]) # adjust corner vertices for recursion
+    return np.concatenate([coords, number_tetrahedron(np.array(corner_verts) + inc, order - 4)], axis=0) # recursive call, decrease order
+
+def vtk_node_ordering(order):
+    return number_tetrahedron(np_array([[0,0,0], [1,0,0], [0,1,0], [0,0,1]]), order)


### PR DESCRIPTION
Hi,
I added support for the conversion of the .h5 files from bichon to .vtu files suitable for visualization in Paraview. It's not particularly elegant as a comparison of point locations computes the node ordering, but it gets the job done! 